### PR TITLE
Sum + Checksum should not be calculated with STX 

### DIFF
--- a/Checksum_SerIn_SOT_EOT_LCD_TOut/Checksum_SerIn_SOT_EOT_LCD_TOut.ino
+++ b/Checksum_SerIn_SOT_EOT_LCD_TOut/Checksum_SerIn_SOT_EOT_LCD_TOut.ino
@@ -54,7 +54,7 @@ void setup()
 
   // Remove Serial prints after debug
 
-  Serial.println("V2A Checksum Test Serial Simulation");//
+  Serial.println("V2B Checksum Test Serial Simulation");//
   /*
     Serial.println("Please enter each Nibble in keyboard. Max 16");//
     Serial.println("Confirm with send");//
@@ -152,7 +152,7 @@ void lcsWaiting()
 {
   lcd.clear();        // clear display
   lcd.setCursor(0, 0); // Position Column 0 , Line 0
-  lcd.print("DATA Monitor V2A");
+  lcd.print("DATA Monitor V2B");
   lcd.setCursor(0, 1); // Position Column 0 , Line
   lcd.print("Waiting....");//
 }

--- a/Checksum_SerIn_SOT_EOT_LCD_TOut/Checksum_SerIn_SOT_EOT_LCD_TOut.ino
+++ b/Checksum_SerIn_SOT_EOT_LCD_TOut/Checksum_SerIn_SOT_EOT_LCD_TOut.ino
@@ -280,7 +280,10 @@ void displayRcvdBytesLcdV2()
 void calcSum()
 {
   sum = 0x00; //removed in V2A from 0xFF
-  for (int i = 0; i < numReceived - 2; i++)
+  // Calculate the sum excluding the first STX (0x02) byte.
+  // The last two bytes are the received checksum and ETX (0x03).
+  // Both are not used in the sum calculation.
+  for (int i = 1; i < numReceived - 2; i++)
   {
     sum += receivedBytes[i]; // add all bytes in Array
   }


### PR DESCRIPTION
We have agreed to calculate the checksum using only the Gauge Code and Gauge Value which basically means that the first byte should be omitted when calculating the sum.

The checksum is then the 2's complement of the sum of bytes.

Closes: jkirk/c172hc-fsmaster#1